### PR TITLE
build: updated Docker image build commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NAME ?= testkube-executor-soapui
+NAME ?= testkube-soapui-executor
 BIN_DIR ?= $(HOME)/bin
 
 build:
@@ -13,7 +13,7 @@ mongo-dev:
 	docker run -p 27017:27017 mongo
 
 docker-build: 
-	docker build -t kubeshop/$(NAME) -f build/agent/Dockerfile .
+	docker build  --platform linux/amd64 -t kubeshop/$(NAME) -f build/agent/Dockerfile .
 
 install-swagger-codegen-mac: 
 	brew install swagger-codegen


### PR DESCRIPTION
## Pull request description 

Building the image on a different architecture than amd64 results in execution error on the Kubernetes clusters running on amd64. This PR addresses that.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-