### PR TITLE
fix: failing tests due to permission issues

### DIFF
--- a/build/agent/Dockerfile
+++ b/build/agent/Dockerfile
@@ -9,6 +9,8 @@ RUN cd cmd/agent;go build -o /runner -mod mod -a .
 FROM smartbear/soapuios-testrunner
 COPY --from=builder /runner /bin/runner
 
+RUN chmod 777 /usr/local/SmartBear && \
+    useradd -m -d /home/soapui -s /bin/bash -u 1001 -r -g root soapui
 USER 1001
 
 ENTRYPOINT ["/bin/runner"]

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -21,6 +21,7 @@ type Params struct {
 	Location        string // RUNNER_LOCATION
 	Token           string // RUNNER_TOKEN
 	Ssl             bool   // RUNNER_SSL
+	Datadir         string // RUNNER_DATADIR
 }
 
 // NewRunner creates a new SoapUIRunner
@@ -33,8 +34,7 @@ func NewRunner() (*SoapUIRunner, error) {
 
 	return &SoapUIRunner{
 		SoapUIExecPath: "/usr/local/SmartBear/EntryPoint.sh",
-		SoapUILogsPath: "/root/.soapuios/logs",
-		Fetcher:        content.NewFetcher(""),
+		SoapUILogsPath: "/home/soapui/.soapuios/logs",
 		Scraper: scraper.NewMinioScraper(
 			params.Endpoint,
 			params.AccessKeyID,
@@ -43,6 +43,7 @@ func NewRunner() (*SoapUIRunner, error) {
 			params.Token,
 			params.Ssl,
 		),
+		Datadir: params.Datadir,
 	}, nil
 }
 
@@ -50,19 +51,19 @@ func NewRunner() (*SoapUIRunner, error) {
 type SoapUIRunner struct {
 	SoapUIExecPath string
 	SoapUILogsPath string
-	Fetcher        content.ContentFetcher
 	Scraper        scraper.Scraper
+	Datadir        string
 }
 
 // Run executes the test and returns the test results
 func (r *SoapUIRunner) Run(execution testkube.Execution) (result testkube.ExecutionResult, err error) {
-	testFile, err := r.Fetcher.Fetch(execution.Content)
-	if err != nil {
+	// check that the datadir exists
+	_, err = os.Stat(r.Datadir)
+	if errors.Is(err, os.ErrNotExist) {
 		return result, err
 	}
 
-	output.PrintEvent("created content path", testFile)
-	setUpEnvironment(execution.Args, testFile)
+	setUpEnvironment(execution.Args, r.Datadir)
 
 	if execution.Content.IsDir() {
 		return testkube.ExecutionResult{}, errors.New("SoapUI executor only tests one project per execution, a directory of projects was given")

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -12,10 +12,6 @@ import (
 
 func TestRun(t *testing.T) {
 	testXML := "./example/REST-Project-1-soapui-project.xml"
-	f := mock.Fetcher{}
-	f.FetchFn = func(content *testkube.TestContent) (path string, err error) {
-		return testXML, nil
-	}
 
 	e := testkube.Execution{
 		Id:            "get_petstore",
@@ -81,9 +77,9 @@ func TestRun(t *testing.T) {
 			defer file.Close()
 
 			runner := SoapUIRunner{
-				Fetcher:        f,
 				SoapUIExecPath: file.Name(),
 				Scraper:        s,
+				Datadir:        testXML,
 			}
 
 			res, err := runner.Run(test.execution)


### PR DESCRIPTION
## Pull request description 

SoapUI tests were failing due to permission issues. This PR fixes that and removes the redundant call to save test files when it is already done in testkube-executor-init.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Changes

- removed code that saves test data - it is already happening in the init container, hence git is not needed anymore (see issue https://github.com/kubeshop/testkube/issues/2472 )
- updated tests
- added home directory for user and updated SmartBear folder permissions in Dockerfile
