### PR TITLE
fix: git command not found

### DIFF
--- a/build/agent/Dockerfile
+++ b/build/agent/Dockerfile
@@ -9,7 +9,8 @@ RUN cd cmd/agent;go build -o /runner -mod mod -a .
 FROM smartbear/soapuios-testrunner
 COPY --from=builder /runner /bin/runner
 
-RUN chmod 777 /usr/local/SmartBear && \
+RUN apt-get update && apt-get install -y git && \
+    chmod 777 /usr/local/SmartBear && \
     useradd -m -d /home/soapui -s /bin/bash -u 1001 -r -g root soapui
 USER 1001
 


### PR DESCRIPTION
## Pull request description 

As SoapUI needed the path to the xml file, the test files are fetched on the beginning of execution, not using the files in the init-container. This PR adds git as a dependency to make sure `--git-files` will work.
Fix for https://github.com/kubeshop/testkube/issues/2472

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-